### PR TITLE
release: bump version to 1.2.7

### DIFF
--- a/pyimouapi/__init__.py
+++ b/pyimouapi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.2.6"
+__version__ = "1.2.7"
 
 from .device import ImouDeviceManager, ImouDevice, ImouChannel
 from .exceptions import (

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="pyimouapi",
-    version="1.2.6",
+    version="1.2.7",
     packages=find_packages(),
     python_requires=">=3.11",
     install_requires=[


### PR DESCRIPTION
Align package version with the 1.2.7 release tag so PyPI publish does not attempt to re-upload 1.2.6.